### PR TITLE
added bufsize=1 to subprocess call when running segalign to make it line buffered

### DIFF
--- a/tools/segalign/runner.py
+++ b/tools/segalign/runner.py
@@ -386,7 +386,7 @@ def run_segalign(args: argparse.Namespace, num_sentinel: int, segalign_args: lis
             beg: int = time.monotonic_ns()
             r_beg = resource.getrusage(resource.RUSAGE_CHILDREN)
 
-        process = subprocess.run(run_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        process = subprocess.run(run_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, bufsize=1, text=True)
 
         for line in process.stdout.splitlines():
             commands.add(line)


### PR DESCRIPTION
added bufsize=1 to subprocess call when running segalign to make it line buffered

FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
