### PR TITLE
updated check for alignment truncation.  lastz can return an exit_code of 0 but still have output on stderr

### DIFF
--- a/tools/batched_lastz/macros.xml
+++ b/tools/batched_lastz/macros.xml
@@ -6,7 +6,7 @@
         </requirements>
     </xml>
     <token name="@TOOL_VERSION@">1.04.22</token>
-    <token name="@VERSION_SUFFIX@">2</token>
+    <token name="@VERSION_SUFFIX@">3</token>
     <token name="@PROFILE@">21.05</token>
     <xml name="citations">
         <citations>


### PR DESCRIPTION
updated check for alignment truncation.  lastz can return an exit_code of 0 but still have output on stderr when an alignment is truncated

FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
