### PR TITLE
Fix lastz call in KegAlign wrapper when scoring matrix is used

### DIFF
--- a/tools/kegalign/macros.xml
+++ b/tools/kegalign/macros.xml
@@ -5,7 +5,7 @@
         </requirements>
     </xml>
     <token name="@TOOL_VERSION@">0.1.2.9</token>
-    <token name="@VERSION_SUFFIX@">2</token>
+    <token name="@VERSION_SUFFIX@">3</token>
     <token name="@PROFILE@">25.0</token>
     <xml name="edam_ontology">
         <edam_operations>

--- a/tools/kegalign/runner.py
+++ b/tools/kegalign/runner.py
@@ -416,17 +416,17 @@ def run_kegalign(args: argparse.Namespace, num_sentinel: int, kegalign_args: lis
 
         process = subprocess.run(run_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, bufsize=1, text=True)
 
-        for line in process.stdout.splitlines():
-            line = inject_inner(line, args.inner)
-            commands.add(line)
-            kegalign_q.put(line)
-
         if len(process.stderr) != 0:
             for line in process.stderr.splitlines():
                 print(line, file=sys.stderr, flush=True)
 
         if process.returncode != 0:
             sys.exit(f"Error: kegalign exited with returncode {process.returncode}")
+
+        for line in process.stdout.splitlines():
+            line = inject_inner(line, args.inner)
+            commands.add(line)
+            kegalign_q.put(line)
 
         if args.debug:
             ns: int = time.monotonic_ns() - beg

--- a/tools/kegalign/runner.py
+++ b/tools/kegalign/runner.py
@@ -23,10 +23,11 @@ def inject_inner(line: str, inner: typing.Optional[int]) -> str:
     if inner is None or " --inner=" in line:
         return line
 
-    if " --segments=" not in line:
+    new_line, count = re.subn(r"( --strand=(?:minus|plus))", rf"\1 --inner={inner}", line, count=1)
+    if count == 0:
         sys.exit(f"Unable to inject --inner into unexpected lastz command: {line}")
 
-    return line.replace(" --segments=", f" --inner={inner} --segments=", 1)
+    return new_line
 
 
 class LastzCommands:


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
