### PR TITLE
ci: adopt the galaxy-tool-refactor forward gate (suggest mode)

### DIFF
--- a/.github/workflows/forward-gate.yml
+++ b/.github/workflows/forward-gate.yml
@@ -1,0 +1,15 @@
+name: forward-gate
+on:
+  pull_request:
+    paths: ["tools/**/*.xml"]
+
+jobs:
+  canonical-form:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0   # the gate diffs the PR against its base
+      - uses: richard-burhans/galaxy-tool-refactor/.github/actions/forward-gate@v0.3.1
+        with:
+          version: "0.3.1"

--- a/.github/workflows/forward-gate.yml
+++ b/.github/workflows/forward-gate.yml
@@ -6,10 +6,14 @@ on:
 jobs:
   canonical-form:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write   # so the gate can post review suggestions
     steps:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0   # the gate diffs the PR against its base
-      - uses: richard-burhans/galaxy-tool-refactor/.github/actions/forward-gate@v0.3.1
+      - uses: richard-burhans/galaxy-tool-refactor/.github/actions/forward-gate@main
         with:
           version: "0.3.1"
+          mode: suggest


### PR DESCRIPTION
Adds `.github/workflows/forward-gate.yml`: on every PR that touches a tool, the published galaxy-tool-refactor forward-gate Action runs in **suggest mode** and posts the canonical, behaviour-preserving fixes as one-click GitHub review suggestions (with the IUC doc link), so authors clean up in place. Non-blocking (the check passes; the suggestions are the deliverable).

Referenced at `@main` for the suggest-mode input; pin to a release tag once one including it is cut. Needs `pull-requests: write` (granted in the workflow). Safe to merge to adopt the gate.