### PR TITLE
[demo] forward-gate suggest mode (not for merge)

### DIFF
--- a/.github/workflows/forward-gate.yml
+++ b/.github/workflows/forward-gate.yml
@@ -1,0 +1,18 @@
+name: forward-gate
+on:
+  pull_request:
+    paths: ["tools/**/*.xml"]
+jobs:
+  canonical-form:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: richard-burhans/galaxy-tool-refactor/.github/actions/forward-gate@main
+        with:
+          version: "0.3.1"
+          mode: suggest

--- a/tools/_suggest_demo/sg.xml
+++ b/tools/_suggest_demo/sg.xml
@@ -1,0 +1,7 @@
+<tool id="suggest_demo" name="Suggest demo" version="1.0+galaxy0" profile="24.0">
+  <description>throwaway tool; intentionally non-canonical to demo suggest mode</description>
+        <command><![CDATA[echo demo]]></command>
+  <inputs/>
+  <outputs/>
+  <help>Demonstration of the forward gate's suggest mode. Not a real tool.</help>
+</tool>


### PR DESCRIPTION
Live test of the forward gate's **suggest mode**: the Action posts the canonical fix for the intentionally non-canonical `tools/_suggest_demo/` as one-click review suggestions. Non-blocking demo; not for merge.