### PR TITLE
ci: pin forward-gate Action to v0.3.2 (suggest mode)

### DIFF
--- a/.github/workflows/forward-gate.yml
+++ b/.github/workflows/forward-gate.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0   # the gate diffs the PR against its base
-      - uses: richard-burhans/galaxy-tool-refactor/.github/actions/forward-gate@main
+      - uses: richard-burhans/galaxy-tool-refactor/.github/actions/forward-gate@v0.3.2
         with:
-          version: "0.3.1"
+          version: "0.3.2"
           mode: suggest


### PR DESCRIPTION
Pin the forward-gate Action ref from `@main` to the immutable `@v0.3.2` tag and bump `version` to `0.3.2`.

0.3.2 is the galaxy-tool-refactor release that ships the `gate-suggest` command suggest mode invokes, so this pin is what makes `mode: suggest` reproducible (an immutable tag instead of a moving branch). `mode: suggest` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)