### PR TITLE
ci: pin forward-gate Action to v0.3.3

### DIFF
--- a/.github/workflows/forward-gate.yml
+++ b/.github/workflows/forward-gate.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0   # the gate diffs the PR against its base
-      - uses: richard-burhans/galaxy-tool-refactor/.github/actions/forward-gate@v0.3.2
+      - uses: richard-burhans/galaxy-tool-refactor/.github/actions/forward-gate@v0.3.3
         with:
-          version: "0.3.2"
+          version: "0.3.3"
           mode: suggest


### PR DESCRIPTION
Re-pin the forward-gate Action from `@v0.3.2` to `@v0.3.3` (and `version` to `0.3.3`).

0.3.3 ships the block-mode fix that narrows the gate to actual `<tool>` documents, so a changed `macros.xml` no longer fails on its cosmetic drift; it also brings the MCP/registry additions. `mode: suggest` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)