### PR TITLE
Upgrade tools: minimal profile bumps + canonical formatting

### DIFF
--- a/tools/batched_lastz/batched_lastz.xml
+++ b/tools/batched_lastz/batched_lastz.xml
@@ -25,18 +25,17 @@
         </section>
     </inputs>
     <outputs>
-        <data name="output" label="Batched LASTZ on ${on_string}" format="auto" />
+        <data name="output" label="Batched LASTZ on ${on_string}" format="auto"/>
     </outputs>
     <tests>
-      <test expect_num_outputs="1">
-        <param name="input" value="input.tgz" ftype="tgz"/>
-        <output name="output">
-            <assert_contents>
-                <has_size min="1"/>
-            </assert_contents>
-        </output>
-
-      </test>
+        <test expect_num_outputs="1">
+            <param name="input" value="input.tgz" ftype="tgz"/>
+            <output name="output">
+                <assert_contents>
+                    <has_size min="1"/>
+                </assert_contents>
+            </output>
+        </test>
     </tests>
     <help><![CDATA[
 Batched LASTZ is a special version of LASTZ designed to process output of Galaxy's KegAlign tool. It outputs pairiwse alignments in a verietry of formats.

--- a/tools/batched_lastz/macros.xml
+++ b/tools/batched_lastz/macros.xml
@@ -7,7 +7,7 @@
     </xml>
     <token name="@TOOL_VERSION@">1.04.22</token>
     <token name="@VERSION_SUFFIX@">7</token>
-    <token name="@PROFILE@">21.05</token>
+    <token name="@PROFILE@">22.01</token>
     <xml name="citations">
         <citations>
             <citation type="bibtex">

--- a/tools/ncbi_egapx/ncbi_egapx.xml
+++ b/tools/ncbi_egapx/ncbi_egapx.xml
@@ -89,8 +89,8 @@
     #end if
     ]]></command>
     <environment_variables>
-         <environment_variable name="NXF_DEBUG">3</environment_variable>
-         <environment_variable name="EGAPX_RNASEQ_QUERY_LIMIT">$getVar('developer.query_limit.rnaseq_query_limit', '20')</environment_variable>
+        <environment_variable name="NXF_DEBUG">3</environment_variable>
+        <environment_variable name="EGAPX_RNASEQ_QUERY_LIMIT">$getVar('developer.query_limit.rnaseq_query_limit', '20')</environment_variable>
     </environment_variables>
     <configfiles>
         <configfile name="short_reads_config"><![CDATA[#slurp
@@ -301,8 +301,7 @@ $row
                 </conditional>
                 <param name="trnascan_enabled" type="boolean" checked="false" label="Enable prediction of tRNA features using tRNAscan."/>
                 <param name="cmsearch_enabled" type="boolean" checked="false" label="Enable prediction of rRNAs, snoRNAs and snRNAs by searching the RFAM database using cmsearch distributed in Infernal."/>
-                <param name="extra" type="text" area="true" optional="true" label="Additional yaml to append to the egapx.yaml configuration"
-                    help="Not normally needed but useful for testing additional configuration elements">
+                <param name="extra" type="text" area="true" optional="true" label="Additional yaml to append to the egapx.yaml configuration" help="Not normally needed but useful for testing additional configuration elements">
                     <sanitizer invalid_char="">
                         <valid initial="string.printable"/>
                     </sanitizer>
@@ -324,7 +323,7 @@ $row
                 </when>
                 <when value="false"/>
             </conditional>
-            <param label="Gigabase pairs" name="gigabase_pairs" type="integer" size="3" min="1" max="8" value="1" help="Approximate gigabase pair count for scheduling hints" />
+            <param label="Gigabase pairs" name="gigabase_pairs" type="integer" size="3" min="1" max="8" value="1" help="Approximate gigabase pair count for scheduling hints"/>
         </section>
     </inputs>
     <outputs>

--- a/tools/ncbi_egapx/ncbi_egapx_execute.xml
+++ b/tools/ncbi_egapx/ncbi_egapx_execute.xml
@@ -25,8 +25,8 @@
     #end if
     ]]></command>
     <environment_variables>
-         <environment_variable name="NXF_DEBUG">3</environment_variable>
-         <environment_variable name="EGAPX_RNASEQ_QUERY_LIMIT">$getVar('developer.query_limit.rnaseq_query_limit', '20')</environment_variable>
+        <environment_variable name="NXF_DEBUG">3</environment_variable>
+        <environment_variable name="EGAPX_RNASEQ_QUERY_LIMIT">$getVar('developer.query_limit.rnaseq_query_limit', '20')</environment_variable>
     </environment_variables>
     <inputs>
         <param name="input_config" type="data" format="yaml" label="EGAPx configuration YAML file to pass to Nextflow"/>

--- a/tools/ncbi_egapx/ncbi_egapx_prepare_input.xml
+++ b/tools/ncbi_egapx/ncbi_egapx_prepare_input.xml
@@ -84,8 +84,8 @@
     '$yamlconfig' --executor galaxy --output 'egapx_out' --download-only --local-cache '$output.extra_files_path'
     ]]></command>
     <environment_variables>
-         <environment_variable name="NXF_DEBUG">3</environment_variable>
-         <environment_variable name="EGAPX_RNASEQ_QUERY_LIMIT">$getVar('developer.query_limit.rnaseq_query_limit', '20')</environment_variable>
+        <environment_variable name="NXF_DEBUG">3</environment_variable>
+        <environment_variable name="EGAPX_RNASEQ_QUERY_LIMIT">$getVar('developer.query_limit.rnaseq_query_limit', '20')</environment_variable>
     </environment_variables>
     <configfiles>
         <configfile name="short_reads_config"><![CDATA[#slurp
@@ -296,8 +296,7 @@ $row
                 </conditional>
                 <param name="trnascan_enabled" type="boolean" checked="false" label="Enable prediction of tRNA features using tRNAscan"/>
                 <param name="cmsearch_enabled" type="boolean" checked="false" label="Enable prediction of rRNAs, snoRNAs and snRNAs by searching the RFAM database using cmsearch distributed in Infernal"/>
-                <param name="extra" type="text" area="true" optional="true" label="Additional YAML to append to the EGAPx configuration"
-                    help="Not normally needed but useful for testing additional configuration elements">
+                <param name="extra" type="text" area="true" optional="true" label="Additional YAML to append to the EGAPx configuration" help="Not normally needed but useful for testing additional configuration elements">
                     <sanitizer invalid_char="">
                         <valid initial="string.printable"/>
                     </sanitizer>
@@ -306,7 +305,7 @@ $row
             <when value="history">
                 <param name="yamlin" type="data" format="yaml" label="EGAPx configuration YAML file to pass to Nextflow"/>
             </when>
-        </conditional> 
+        </conditional>
         <section name="developer" title="Developer options" expanded="false">
             <conditional name="query_limit">
                 <param name="query_limit_selector" type="select" label="Enforce SRA query limit">

--- a/tools/ncbi_fcs_adaptor/ncbi_fcs_adaptor.xml
+++ b/tools/ncbi_fcs_adaptor/ncbi_fcs_adaptor.xml
@@ -35,23 +35,23 @@
         <test expect_num_outputs="2">
             <param name="input" value="fcsadaptor_prok_test.fa.gz" ftype="fasta"/>
             <param name="tax" value="--prok"/>
-            <output name="adaptor_report" file="adaptor_report.tab" ftype="tabular" />
-            <output name="clean_fasta" decompress="true" file="clean_fasta.fa.gz" ftype="fasta" />
+            <output name="adaptor_report" file="adaptor_report.tab" ftype="tabular"/>
+            <output name="clean_fasta" decompress="true" file="clean_fasta.fa.gz" ftype="fasta"/>
         </test>
         <test expect_num_outputs="4">
             <param name="input" value="fcsadaptor_prok_test.fa.gz" ftype="fasta"/>
             <param name="tax" value="--prok"/>
             <param name="optional_log" value="adaptor_log,validate_fasta_log"/>
-            <output name="adaptor_report" file="adaptor_report.tab" ftype="tabular" />
-            <output name="clean_fasta" decompress="true" file="clean_fasta.fa.gz" ftype="fasta" />
+            <output name="adaptor_report" file="adaptor_report.tab" ftype="tabular"/>
+            <output name="clean_fasta" decompress="true" file="clean_fasta.fa.gz" ftype="fasta"/>
             <output name="adaptor_log">
                 <assert_contents>
-                    <has_text_matching expression="\bINFO \[workflow \] completed success\b" />
+                    <has_text_matching expression="\bINFO \[workflow \] completed success\b"/>
                 </assert_contents>
             </output>
             <output name="validate_fasta_log">
                 <assert_contents>
-                    <has_size value="0" />
+                    <has_size value="0"/>
                 </assert_contents>
             </output>
         </test>

--- a/tools/rdeval/macros.xml
+++ b/tools/rdeval/macros.xml
@@ -15,7 +15,7 @@
     </xml>
     <token name="@TOOL_VERSION@">0.0.9</token>
     <token name="@VERSION_SUFFIX@">0</token>
-    <token name="@PROFILE@">23.02</token>
+    <token name="@PROFILE@">24.0</token>
     <xml name="citations">
         <citations>
             <citation type="doi">10.1101/2025.02.01.636073</citation>

--- a/tools/rdeval/rdeval.xml
+++ b/tools/rdeval/rdeval.xml
@@ -100,28 +100,28 @@
                     <param name="length_comparison" type="select" label="Retain reads with length">
                         <option value="&lt;" selected="true">less than</option>
                         <option value="=">equal to</option>
-                        <option value=">">greater than</option>
+                        <option value="&gt;">greater than</option>
                         <sanitizer sanitize="false"/>
                     </param>
-                    <param name="length_value" type="integer" min="0" value="0" label="Length in bp" />
+                    <param name="length_value" type="integer" min="0" value="0" label="Length in bp"/>
                 </when>
                 <when value="q_exp">
                     <param name="quality_comparison" type="select" label="Retain reads with average read quality">
                         <option value="&lt;" selected="true">less than</option>
                         <option value="=">equal to</option>
-                        <option value=">">greater than</option>
+                        <option value="&gt;">greater than</option>
                         <sanitizer sanitize="false"/>
                     </param>
-                    <param name="quality_value" type="integer" min="0" value="0" label="Average read quality" />
+                    <param name="quality_value" type="integer" min="0" value="0" label="Average read quality"/>
                 </when>
                 <when value="lq_exp">
                     <param name="length_comparison" type="select" label="Retain reads with length">
                         <option value="&lt;" selected="true">less than</option>
                         <option value="=">equal to</option>
-                        <option value=">">greater than</option>
+                        <option value="&gt;">greater than</option>
                         <sanitizer sanitize="false"/>
                     </param>
-                    <param name="length_value" type="integer" min="0" value="0" label="Length in bp" />
+                    <param name="length_value" type="integer" min="0" value="0" label="Length in bp"/>
                     <param name="exp_operator" type="select" label="Combination operator">
                         <option value="|" selected="true">or</option>
                         <option value="&amp;">and</option>
@@ -130,10 +130,10 @@
                     <param name="quality_comparison" type="select" label="Average read quality">
                         <option value="&lt;" selected="true">less than</option>
                         <option value="=">equal to</option>
-                        <option value=">">greater than</option>
+                        <option value="&gt;">greater than</option>
                         <sanitizer sanitize="false"/>
                     </param>
-                    <param name="quality_value" type="integer" min="0" value="0" label="average read quality" />
+                    <param name="quality_value" type="integer" min="0" value="0" label="average read quality"/>
                 </when>
             </conditional>
         </section>
@@ -235,10 +235,10 @@
             <section name="input_filter">
                 <conditional name="filter_expression">
                     <param name="filter_selector" value="lq_exp"/>
-                    <param name="length_comparison" value=">"/>
+                    <param name="length_comparison" value="&gt;"/>
                     <param name="length_value" value="10"/>
                     <param name="exp_operator" value="&amp;"/>
-                    <param name="quality_comparison" value=">"/>
+                    <param name="quality_comparison" value="&gt;"/>
                     <param name="quality_value" value="10"/>
                 </conditional>
             </section>

--- a/tools/segalign/macros.xml
+++ b/tools/segalign/macros.xml
@@ -6,7 +6,7 @@
     </xml>
     <token name="@TOOL_VERSION@">0.1.2.7</token>
     <token name="@VERSION_SUFFIX@">1</token>
-    <token name="@PROFILE@">21.05</token>
+    <token name="@PROFILE@">22.01</token>
     <xml name="edam_ontology">
         <edam_operations>
             <edam_operation>operation_0491</edam_operation>


### PR DESCRIPTION
Ran `galaxy-tool-refactor upgrade` (minimal-bump default) across the repo. **9 files changed; the pass is idempotent and every tool still validates.**

## Profile bumps (3) — each strictly needed for validity
Three shared `@PROFILE@` macro tokens move to the **minimum** profile at which the tool validates (they are invalid at the current value, so this is the conservative minimal bump, not a walk):

| Macro file | `@PROFILE@` | Min-valid |
|---|---|---|
| `tools/batched_lastz/macros.xml` | `21.05 → 22.01` | 22.01 |
| `tools/segalign/macros.xml` | `21.05 → 22.01` | 22.01 |
| `tools/rdeval/macros.xml` | `23.02 → 24.0` | 24.0 |

Tools already valid at their declared profile (e.g. `ncbi_egapx` at 25.0) are **kept** unchanged. The bumps are applied in the macro file with all importers in agreement.

## Canonical formatting (6 tools)
The format pass `upgrade` runs at the end: empty-element shorthand (`<data .../>`), consistent indentation, `<tests>` re-indent. Behavior-preserving (serialized bytes only).

## Safety
- Minimal-bump: `profile=` moves only where strictly needed for validity.
- Re-running the upgrade is a no-op (idempotent).
- Behavior-preserving by construction; deterministic, no LLM.

Generated with `galaxy-tool-refactor` 0.3.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
